### PR TITLE
comment type query changed for giving support with latest wordpress

### DIFF
--- a/singletons/introspector.php
+++ b/singletons/introspector.php
@@ -1,7 +1,7 @@
 <?php
 
 class JSON_API_Introspector {
-  
+
   public function get_posts($query = false, $wp_posts = false) {
     global $post, $wp_query;
     $this->set_posts_query($query);
@@ -17,13 +17,13 @@ class JSON_API_Introspector {
     }
     return $output;
   }
-  
+
   public function get_date_archive_permalinks() {
     $archives = wp_get_archives('echo=0');
     preg_match_all("/href='([^']+)'/", $archives, $matches);
     return $matches[1];
   }
-  
+
   public function get_date_archive_tree($permalinks) {
     $tree = array();
     foreach ($permalinks as $url) {
@@ -47,7 +47,7 @@ class JSON_API_Introspector {
     }
     return $tree;
   }
-  
+
   public function get_date_archive_count($year, $month) {
     if (!isset($this->month_archives)) {
       global $wpdb;
@@ -66,7 +66,7 @@ class JSON_API_Introspector {
     }
     return $this->month_archives["$year$month"];
   }
-  
+
   public function get_categories($args = null) {
     $wp_categories = get_categories($args);
     $categories = array();
@@ -78,7 +78,7 @@ class JSON_API_Introspector {
     }
     return $categories;
   }
-  
+
   public function get_current_post() {
     global $json_api;
     extract($json_api->query->get(array('id', 'slug', 'post_id', 'post_slug')));
@@ -105,7 +105,7 @@ class JSON_API_Introspector {
       return null;
     }
   }
-  
+
   public function get_current_category() {
     global $json_api;
     extract($json_api->query->get(array('id', 'slug', 'category_id', 'category_slug')));
@@ -124,22 +124,22 @@ class JSON_API_Introspector {
     }
     return null;
   }
-  
+
   public function get_category_by_id($category_id) {
     $wp_category = get_term_by('id', $category_id, 'category');
     return $this->get_category_object($wp_category);
   }
-  
+
   public function get_category_by_slug($category_slug) {
     $wp_category = get_term_by('slug', $category_slug, 'category');
     return $this->get_category_object($wp_category);
   }
-  
+
   public function get_tags() {
     $wp_tags = get_tags();
     return array_map(array(&$this, 'get_tag_object'), $wp_tags);
   }
-  
+
   public function get_current_tag() {
     global $json_api;
     extract($json_api->query->get(array('id', 'slug', 'tag_id', 'tag_slug')));
@@ -158,17 +158,17 @@ class JSON_API_Introspector {
     }
     return null;
   }
-  
+
   public function get_tag_by_id($tag_id) {
     $wp_tag = get_term_by('id', $tag_id, 'post_tag');
     return $this->get_tag_object($wp_tag);
   }
-  
+
   public function get_tag_by_slug($tag_slug) {
     $wp_tag = get_term_by('slug', $tag_slug, 'post_tag');
     return $this->get_tag_object($wp_tag);
   }
-  
+
   public function get_authors() {
     global $wpdb;
     $author_ids = $wpdb->get_col("
@@ -183,7 +183,7 @@ class JSON_API_Introspector {
     $active_authors = array_filter($all_authors, array(&$this, 'is_active_author'));
     return $active_authors;
   }
-  
+
   public function get_current_author() {
     global $json_api;
     extract($json_api->query->get(array('id', 'slug', 'author_id', 'author_slug')));
@@ -202,7 +202,7 @@ class JSON_API_Introspector {
     }
     return null;
   }
-  
+
   public function get_author_by_id($id) {
     $id = get_the_author_meta('ID', $id);
     if (!$id) {
@@ -210,7 +210,7 @@ class JSON_API_Introspector {
     }
     return new JSON_API_Author($id);
   }
-  
+
   public function get_author_by_login($login) {
     global $wpdb;
     $id = $wpdb->get_var($wpdb->prepare("
@@ -220,7 +220,7 @@ class JSON_API_Introspector {
     ", $login));
     return $this->get_author_by_id($id);
   }
-  
+
   public function get_comments($post_id) {
     global $wpdb;
     $wp_comments = $wpdb->get_results($wpdb->prepare("
@@ -228,7 +228,7 @@ class JSON_API_Introspector {
       FROM $wpdb->comments
       WHERE comment_post_ID = %d
         AND comment_approved = 1
-        AND comment_type = ''
+        AND comment_type = '' OR comment_type = 'comment'
       ORDER BY comment_date
     ", $post_id));
     $comments = array();
@@ -237,7 +237,7 @@ class JSON_API_Introspector {
     }
     return $comments;
   }
-  
+
   public function get_attachments($post_id) {
     $wp_attachments = get_children(array(
       'post_type' => 'attachment',
@@ -254,7 +254,7 @@ class JSON_API_Introspector {
     }
     return $attachments;
   }
-  
+
   public function get_attachment($attachment_id) {
     global $wpdb;
     $wp_attachment = $wpdb->get_row(
@@ -266,7 +266,7 @@ class JSON_API_Introspector {
     );
     return new JSON_API_Attachment($wp_attachment);
   }
-  
+
   public function attach_child_posts(&$post) {
     $post->children = array();
     $wp_children = get_posts(array(
@@ -286,21 +286,21 @@ class JSON_API_Introspector {
       $this->attach_child_posts($child);
     }
   }
-  
+
   protected function get_category_object($wp_category) {
     if (!$wp_category) {
       return null;
     }
     return new JSON_API_Category($wp_category);
   }
-  
+
   protected function get_tag_object($wp_tag) {
     if (!$wp_tag) {
       return null;
     }
     return new JSON_API_Tag($wp_tag);
   }
-  
+
   protected function is_active_author($author) {
     if (!isset($this->active_authors)) {
       $this->active_authors = explode(',', wp_list_authors(array(
@@ -312,34 +312,34 @@ class JSON_API_Introspector {
     }
     return in_array($author->name, $this->active_authors);
   }
-  
+
   protected function set_posts_query($query = false) {
     global $json_api, $wp_query;
-    
+
     if (!$query) {
       $query = array();
     }
-    
+
     $query = array_merge($query, $wp_query->query);
-    
+
     if ($json_api->query->page) {
       $query['paged'] = $json_api->query->page;
     }
-    
+
     if ($json_api->query->count) {
       $query['posts_per_page'] = $json_api->query->count;
     }
-    
+
     if ($json_api->query->post_type) {
       $query['post_type'] = $json_api->query->post_type;
     }
-    
+
     if (!empty($query)) {
       query_posts($query);
       do_action('json_api_query', $wp_query);
     }
   }
-  
+
 }
 
 ?>


### PR DESCRIPTION
In latest wordpress version it's returning empty comment for every post. this fix will solve that issue.