### PR TITLE
Fatal bug fix of deprecated function in PHP 8

### DIFF
--- a/singletons/query.php
+++ b/singletons/query.php
@@ -87,11 +87,12 @@ class JSON_API_Query {
   }
   
   function strip_magic_quotes($value) {
-    if (get_magic_quotes_gpc()) {
-      return stripslashes($value);
-    } else {
+    // Deprecated!
+	//if (get_magic_quotes_gpc()) {
+    //  return stripslashes($value);
+    //} else {
       return $value;
-    }
+    //}
   }
   
   function query_vars($wp_vars) {
@@ -192,3 +193,4 @@ class JSON_API_Query {
   }
   
 }
+?>


### PR DESCRIPTION
Fatal bug fix of deprecated function in PHP 8 --> PHP: get_magic_quotes_gpc - Manual ( https://www.php.net/manual/en/function.get-magic-quotes-gpc.php )