### PR TITLE
Added query params support

### DIFF
--- a/singletons/introspector.php
+++ b/singletons/introspector.php
@@ -334,7 +334,27 @@ class JSON_API_Introspector {
     if ($json_api->query->post_type) {
       $query['post_type'] = $json_api->query->post_type;
     }
-    
+	
+	if ($json_api->query->post_status) {
+      $query['post_status'] = $json_api->query->post_status;
+    }
+
+    if ($json_api->query->category_id) {
+	  $query['cat'] = $json_api->query->category_id;
+    }
+
+    if ($json_api->query->category_slug) {
+	  $query['category_name'] = $json_api->query->category_slug;
+    }
+
+    if ($json_api->query->tag_id) {
+	  $query['tag_id'] = $json_api->query->tag_id;
+    }
+
+    if ($json_api->query->tag_slug) {
+	  $query['tag'] = $json_api->query->tag_slug;
+    }
+
     if (!empty($query)) {
       query_posts($query);
       do_action('json_api_query', $wp_query);
@@ -342,3 +362,4 @@ class JSON_API_Introspector {
   }
   
 }
+?>


### PR DESCRIPTION
I've added a few lines to enabled finer control over post queries, by allowing post_status, category, and tag filtering from any o the list methods (like get_category_posts). This allows calls to make complex queries like: get posts from a certain category that also have a certain tag and aren't yet published.