### PR TITLE
Added meta data and date settings at post creation

### DIFF
--- a/models/post.php
+++ b/models/post.php
@@ -78,6 +78,10 @@ class JSON_API_Post {
       $author = $json_api->introspector->get_author_by_login($values['author']);
       $wp_values['post_author'] = $author->id;
     }
+	
+	if (!empty($values['date'])) {
+      $wp_values['post_date'] = $values['date'];
+    }
     
     if (isset($values['categories'])) {
       $categories = explode(',', $values['categories']);
@@ -108,6 +112,13 @@ class JSON_API_Post {
       $this->id = wp_update_post($wp_values);
     } else {
       $this->id = wp_insert_post($wp_values);
+    }
+	
+	if (isset($values['meta'])) {
+      $meta = $values['meta'];
+      foreach ($meta as $meta_key => $meta_value) {
+		 update_post_meta($this->id, $meta_key, $meta_value);
+      }
     }
     
     if (!empty($_FILES['attachment'])) {
@@ -316,4 +327,4 @@ class JSON_API_Post {
   
 }
 
-
+?>


### PR DESCRIPTION
Added the parameters 'date' and 'meta' to the 'create_post' function.

- The parameter is mapped to 'post_date' in Wordpress.
- The parameter 'meta' contains an array of 'key' => 'value'. The Wordpress function 'update_post_meta' is called for each pair at post creation.