### PR TITLE
Correct headers update

### DIFF
--- a/singletons/api.php
+++ b/singletons/api.php
@@ -410,10 +410,10 @@ class JSON_API {
     $wp_rewrite->flush_rules();
   }
   
-  function error($message = 'Unknown error', $status = 'error') {
+  function error($message = 'Unknown error', $status = 'error', $header = '400') {
     $this->response->respond(array(
       'error' => $message
-    ), $status);
+    ), $status, $header);
   }
   
   function include_value($key) {
@@ -422,3 +422,4 @@ class JSON_API {
   
 }
 
+?>


### PR DESCRIPTION
I've added some functionality to error method in API.php and output, response in response.php
This might look ugly but the Idea is to have certain headers to be served when wrong syntax used in queries or authentication has failed.

Currently there's only 200 which is pretty annoying when working with backbone.js

Please feel free to criticize my code I am new to PHP and will fix it accordingly.

Proposed code is working at http://nuwaxrecords.com/api/
400 http://www.nuwaxrecords.com/api/get_nonce/