### PR TITLE
A small inaccuracy that leads to an error (400).

### DIFF
--- a/singletons/response.php
+++ b/singletons/response.php
@@ -105,7 +105,7 @@ class JSON_API_Response {
   function output($result, $header) {
     $charset = get_option('blog_charset');
     if (!headers_sent()) {
-      header("HTTP/1.1 ${$header}", true);
+      header("HTTP/1.1 $header", true);
       header("Content-Type: application/json; charset=$charset", true);
     }
     echo $result;


### PR DESCRIPTION
Found a small inaccuracy that led to an error:
 Undefined variable: 400 in C:\home\htdocs.wordpress\wp-content\plugins\json-api-master\singletons\response.php:108

It was like this:
  header("HTTP/1.1 ${$header}", true);

Now it works like this:
  header("HTTP/1.1 $header", true);